### PR TITLE
Add `linux-libc.riscv64`

### DIFF
--- a/Dockerfile.android.base
+++ b/Dockerfile.android.base
@@ -30,10 +30,9 @@ ENV AR=${CROSS_BIN}/llvm-ar \
     STRIP=${CROSS_BIN}/llvm-strip
 
 RUN echo 'Setting up JNI header files for linux' && \
-    for jversion in $(echo ${JNI_JAVA_VERSIONS} | tr "," " "); do       \
-      cd ${JNI_H}/${jversion}/include;                                  \
-      ln -s linux/jni_md.h jni_md.h;                                    \
-      if [ "$jversion" != "java6" ]; then continue; fi;                 \
-      ln -s linux/jni.h jni.h;                                          \
+    for jversion in $(echo "java6,java8,java11,java17,java21" | tr "," " "); do     \
+      cd ${JNI_H}/${jversion}/include;                                              \
+      ln -s linux/jni_md.h jni_md.h;                                                \
+      if [ "$jversion" != "java6" ]; then continue; fi;                             \
+      ln -s linux/jni.h jni.h;                                                      \
     done
-

--- a/Dockerfile.darwin.base
+++ b/Dockerfile.darwin.base
@@ -80,9 +80,9 @@ RUN echo 'Building apple-libtapi' && \
     rm -rf /build
 
 RUN echo 'Setting up JNI header files for darwin' && \
-    for jversion in $(echo ${JNI_JAVA_VERSIONS} | tr "," " "); do       \
-      cd ${JNI_H}/${jversion}/include;                                  \
-      ln -s darwin/jni_md.h jni_md.h;                                   \
-      if [ "$jversion" != "java6" ]; then continue; fi;                 \
-      ln -s darwin/jni.h jni.h;                                         \
+    for jversion in $(echo "java6,java8,java11,java17,java21" | tr "," " "); do     \
+      cd ${JNI_H}/${jversion}/include;                                              \
+      ln -s darwin/jni_md.h jni_md.h;                                               \
+      if [ "$jversion" != "java6" ]; then continue; fi;                             \
+      ln -s darwin/jni.h jni.h;                                                     \
     done

--- a/Dockerfile.linux-libc.base
+++ b/Dockerfile.linux-libc.base
@@ -1,4 +1,4 @@
-FROM amd64/ubuntu:16.04
+FROM amd64/ubuntu:18.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -74,12 +74,11 @@ RUN echo 'Building cmake' && \
     cd / && \
     rm -rf /build
 
-ENV JNI_H=/usr/local/jni \
-    JNI_JAVA_VERSIONS=java6,java8,java11,java17,java21
+ENV JNI_H=/usr/local/jni
 
 RUN echo 'Setting up JNI header files for linux' && \
     mkdir -p ${JNI_H} && \
-    for jversion in $(echo ${JNI_JAVA_VERSIONS} | tr "," " "); do                                                               \
+    for jversion in $(echo "java6,java8,java11,java17,java21" | tr "," " "); do                                                 \
       cd ${JNI_H};                                                                                                              \
       curl -O https://raw.githubusercontent.com/05nelsonm/build-env/sdk/jni/${jversion}.tar.gz ;                                \
       if [ "${jversion}" = "java6" ]; then SHA256_JNI="bad72b7e9aefcc3e592fee59034a8754782b26087e6c3620f717d1a63338e676"; fi;   \

--- a/Dockerfile.linux-libc.riscv64
+++ b/Dockerfile.linux-libc.riscv64
@@ -1,0 +1,20 @@
+FROM 05nelsonm/build-env.linux-libc.base:latest
+
+RUN echo 'Installing packages for riscv64' && \
+    apt-get update --yes && \
+    apt-get install --yes \
+      g++-riscv64-linux-gnu \
+      gcc-riscv64-linux-gnu \
+      pkg-config-riscv64-linux-gnu
+
+ENV CROSS_TRIPLE=riscv64-linux-gnu
+ENV CROSS_BIN=/usr/bin
+
+ENV AR=${CROSS_BIN}/${CROSS_TRIPLE}-ar \
+    AS=${CROSS_BIN}/${CROSS_TRIPLE}-as \
+    CC=${CROSS_BIN}/${CROSS_TRIPLE}-gcc \
+    CPP=${CROSS_BIN}/${CROSS_TRIPLE}-cpp \
+    CXX=${CROSS_BIN}/${CROSS_TRIPLE}-g++ \
+    LD=${CROSS_BIN}/${CROSS_TRIPLE}-ld \
+    RANLIB=${CROSS_BIN}/${CROSS_TRIPLE}-ranlib \
+    STRIP=${CROSS_BIN}/${CROSS_TRIPLE}-strip

--- a/Dockerfile.mingw.x86
+++ b/Dockerfile.mingw.x86
@@ -26,9 +26,9 @@ ENV WIDL=${CROSS_BIN}/${CROSS_TRIPLE}-widl \
     WINDRES=${CROSS_BIN}/${CROSS_TRIPLE}-windres
 
 RUN echo 'Setting up JNI header files for win32' && \
-    for jversion in $(echo ${JNI_JAVA_VERSIONS} | tr "," " "); do       \
-      cd ${JNI_H}/${jversion}/include;                                  \
-      ln -s win32/jni_md.h jni_md.h;                                    \
-      if [ "$jversion" != "java6" ]; then continue; fi;                 \
-      ln -s win32/jni.h jni.h;                                          \
+    for jversion in $(echo "java6,java8,java11,java17,java21" | tr "," " "); do     \
+      cd ${JNI_H}/${jversion}/include;                                              \
+      ln -s win32/jni_md.h jni_md.h;                                                \
+      if [ "$jversion" != "java6" ]; then continue; fi;                             \
+      ln -s win32/jni.h jni.h;                                                      \
     done

--- a/Dockerfile.mingw.x86_64
+++ b/Dockerfile.mingw.x86_64
@@ -26,9 +26,9 @@ ENV WIDL=${CROSS_BIN}/${CROSS_TRIPLE}-widl \
     WINDRES=${CROSS_BIN}/${CROSS_TRIPLE}-windres
 
 RUN echo 'Setting up JNI header files for win32' && \
-    for jversion in $(echo ${JNI_JAVA_VERSIONS} | tr "," " "); do       \
-      cd ${JNI_H}/${jversion}/include;                                  \
-      ln -s win32/jni_md.h jni_md.h;                                    \
-      if [ "$jversion" != "java6" ]; then continue; fi;                 \
-      ln -s win32/jni.h jni.h;                                          \
+    for jversion in $(echo "java6,java8,java11,java17,java21" | tr "," " "); do     \
+      cd ${JNI_H}/${jversion}/include;                                              \
+      ln -s win32/jni_md.h jni_md.h;                                                \
+      if [ "$jversion" != "java6" ]; then continue; fi;                             \
+      ln -s win32/jni.h jni.h;                                                      \
     done

--- a/Dockerfile.non-linux.base
+++ b/Dockerfile.non-linux.base
@@ -35,13 +35,12 @@ RUN echo 'Preparing base' && \
     apt-get autoremove --yes && \
     rm -rf /etc/ssh/*key*
 
-ENV JNI_H=/usr/local/jni \
-    JNI_JAVA_VERSIONS=java6,java8,java11,java17,java21
+ENV JNI_H=/usr/local/jni
 
 RUN echo 'Installing JNI header files' && \
     mkdir -p ${JNI_H} && \
     cd ${JNI_H} && \
-    for jversion in $(echo ${JNI_JAVA_VERSIONS} | tr "," " "); do                                                               \
+    for jversion in $(echo "java6,java8,java11,java17,java21" | tr "," " "); do                                                 \
       curl -O https://raw.githubusercontent.com/05nelsonm/build-env/sdk/jni/${jversion}.tar.gz ;                                \
       if [ "${jversion}" = "java6" ]; then SHA256_JNI="bad72b7e9aefcc3e592fee59034a8754782b26087e6c3620f717d1a63338e676"; fi;   \
       if [ "${jversion}" = "java8" ]; then SHA256_JNI="697684bbc35ee9732286c7fd8874a9a5758ba7d0ba9a7ddfc462b73cc552de2b"; fi;   \

--- a/task.sh
+++ b/task.sh
@@ -55,6 +55,7 @@ function build:all:linux-libc { ## Builds all Linux Libc images
   build:linux-libc:aarch64
   build:linux-libc:armv7a
   build:linux-libc:ppc64le
+  build:linux-libc:riscv64
   build:linux-libc:x86
   build:linux-libc:x86_64
 }
@@ -157,6 +158,13 @@ function build:linux-libc:ppc64le { ## Builds Linux Libc ppc64le
   local os_name="linux"
   local os_subtype="-libc"
   local os_arch="ppc64le"
+  __exec:docker:assemble
+}
+
+function build:linux-libc:riscv64 { ## Builds Linux Libc riscv64
+  local os_name="linux"
+  local os_subtype="-libc"
+  local os_arch="riscv64"
   __exec:docker:assemble
 }
 


### PR DESCRIPTION
Closes #28 

Bumps `linux-libc.base` from Ubuntu `16.04` -> `18.04`, which in turn bumps:
 - `gcc` from `5.4.0` -> `7.5.0`
 - `glibc` from `2.23` -> `2.27`